### PR TITLE
Seperate out dev and prod dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,11 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-isort = "^5.10.1"
-pytest = "^6.2.5"
 pydantic = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
-
+isort = "^5.10.1"
+pytest = "^6.2.5"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Resolves: #4

Seperates out dev and prod dependencies to avoid blending them in production, and helps with dependency resolution